### PR TITLE
Update dompurify to 3.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
-        "dompurify": "^3.0.8"
+        "dompurify": "^3.2.2"
       },
       "devDependencies": {
         "@commitlint/cli": "^18.4.4",
@@ -2704,10 +2704,11 @@
       "dev": true
     },
     "node_modules/@types/trusted-types": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.0.tgz",
-      "integrity": "sha512-I8MnZqNXsOLHsU111oHbn3khtvKMi5Bn4qVFsIWSJcCP1KKDiXX5AEw8UPk0nSopeC+Hvxt6yAy1/a5PailFqg==",
-      "dev": true
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.24",
@@ -4091,9 +4092,13 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.8.tgz",
-      "integrity": "sha512-b7uwreMYL2eZhrSCRC4ahLTeZcPZxSmYfmcQGXGkXiZSNW1X85v+SDM5KsWcpivIiUBH47Ji7NtyUdpLeF5JZQ=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.2.tgz",
+      "integrity": "sha512-YMM+erhdZ2nkZ4fTNRTSI94mb7VG7uVF5vj5Zde7tImgnhZE3R6YW/IACGIHb2ux+QkEXMhe591N+5jWOmL4Zw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "dompurify": "^3.0.8"
+    "dompurify": "^3.2.2"
   },
   "peerDependencies": {
     "react": "^16.2.0 || ^17.0.0 || ^18.0.0"

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -22,5 +22,5 @@ export function getAttributes(elementAttributes: NamedNodeMap) {
 }
 
 export function parse(html: string, config: Config): DocumentFragment {
-  return dompurify.sanitize(html, config.dom) as DocumentFragment;
+  return dompurify.sanitize(html, config.dom) as unknown as DocumentFragment;
 }


### PR DESCRIPTION
### What
Update dompurify to 3.2.2 and add a type covnersion.

### Why
dompurify < 3.1.3 has a vulnerability explained here https://www.cve.org/CVERecord?id=CVE-2024-47875



